### PR TITLE
feat(schema) Populate movie name based on title field

### DIFF
--- a/db/migrations/20180430094742_add_name_to_movies.js
+++ b/db/migrations/20180430094742_add_name_to_movies.js
@@ -1,0 +1,23 @@
+'use strict';
+
+exports.up = function (knex) {
+  return knex.schema.table('movies', (table) => {
+    table.text('name');
+  })
+  .then(() => {
+    return knex.raw(
+      'ALTER TABLE movies ALTER COLUMN title DROP NOT NULL'
+    );
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  })
+  .then(() => {
+    return knex.raw(
+      'ALTER TABLE movies ALTER COLUMN title SET NOT NULL'
+    );
+  });
+};

--- a/db/migrations/20180430095841_backfill_movie_name.js
+++ b/db/migrations/20180430095841_backfill_movie_name.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.up = function (knex) {
+  return knex.raw(
+    'UPDATE movies SET name = title WHERE name IS NULL'
+  );
+};
+
+exports.down = function (knex, Promise) {
+  return Promise.resolve();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,6 +3,9 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
-  return new Movie().save(payload)
+  const movie_payload = Object.assign({}, payload);
+  movie_payload.name = movie_payload.title;
+
+  return new Movie().save(movie_payload)
   .then((movie) => new Movie({ id: movie.id }).fetch());
 };

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -7,11 +7,20 @@ describe('movie controller', () => {
   describe('create', () => {
 
     it('creates a movie', () => {
-      const payload = { title: 'Bullet' };
+      const payload = { title: 'Bullitt' };
 
       return Controller.create(payload)
       .then((movie) => {
         expect(movie.get('title')).to.eql(payload.title);
+      });
+    });
+
+    it('populates name from title', () => {
+      const payload = { title: 'Bullitt' };
+
+      return Controller.create(payload)
+      .then((movie) => {
+        expect(movie.get('name')).to.eql(payload.title);
       });
     });
 


### PR DESCRIPTION
**What:**

Write the value provided for `title` to the `name` field in `movies`. This **must** be deployed after #5 . Additionally, run migration to backfill `name` field for existing movies.

**Why:**

After deploying and running this migration we'll have good data for `name` in all `movie` rows. At that point we can stop writing to `title` and drop the column.